### PR TITLE
Pull request title now starts with github issue prefix, which breaks this addon. 

### DIFF
--- a/data/tweaks.js
+++ b/data/tweaks.js
@@ -23,9 +23,14 @@ function send(bugNumber, pullRequestURL) {
 
 // Search for a bug number in a string starting with: "bug ######"
 function getBugNumber(str) {
-  var parts = str.split(" ");
-  return (parts.length > 1 &&
-          parts[0].toLowerCase() == "bug" &&
-          parts[1].search(/^[0-9]{6}/) != -1)
-    ? parts[1].substr(0, 6) : null;
+  // Normalize string
+  var parts = String(str).toLowerCase().
+                          // Split into parts.
+                          split(/\s+|\-+/g).
+                          // Remove empty parts.
+                          filter(function(part) { return !!part; });
+  // Index of a bug number argument.
+  var index = parts.indexOf("bug") + 1;
+  // If bug is followed by a bug number return it otherwise `null`.
+  return /^[0-9]{6}/.test(parts[index]) ? parts[index] : null;
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "github-and-bugzilla", 
     "license": "MPL 1.1/GPL 2.0/LGPL 2.1", 
     "author": "Dietrich Ayala", 
-    "version": "1.3", 
+    "version": "1.4",
     "fullName": "Github tweaks for Bugzilla", 
     "id": "jid0-AWShpy08txla2QGDYvv5bed4sjs", 
     "description": "A set of changes to Github that make it easier to integrate with bugzilla.mozilla.org."


### PR DESCRIPTION
Change updates bug-number parser so that it can handle this and hopefully further changes in github pull request page.
