### PR TITLE
Fix for the broken merge "pull request button"

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,7 @@ const attachmentDetailsURL = "https://bugzilla.mozilla.org/attachment.cgi?action
 //const attachmentDetailsURL = "https://landfill.bugzilla.org/bzapi_sandbox/attachment.cgi?action=edit&id=";
 
 pageMod.PageMod({
-  include: "https://github.com/*",
+  include: /https:\/\/github.com\/.*\/pull\/.*/,
   contentScriptWhen: "end",
   contentScriptFile: data.url("tweaks.js"),
   onAttach: function onAttach(worker, mod) {


### PR DESCRIPTION
I don't yet know if the issue is jetpack related or specific to the js in the pull request page. I'll try investigate, but it looks like that [adding a new tab](https://github.com/autonome/Github-Bugzilla-Tweaks/blob/master/data/tweaks.js#L17) was causing an error.
