### PR TITLE
Update to most recent jetpack; warn about multiple creds.

### DIFF
--- a/lib/bugzilla.js
+++ b/lib/bugzilla.js
@@ -40,7 +40,7 @@ exports.Bugzilla = {
     if (options.username && options.password)
       headers["Authorization"] = "Basic " + require("base64").base64encode(options.username + ":" + options.password);
 
-    return require("request").Request({
+    return require("sdk/request").Request({
       url: url,
       headers: headers,
       contentType: "application/json",

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,5 +1,5 @@
-const data = require("self").data;
-const pageMod = require("page-mod");
+const data = require("sdk/self").data;
+const pageMod = require("sdk/page-mod");
 const Bugzilla = require("bugzilla").Bugzilla;
 
 const bzUIURL = "https://bugzilla.mozilla.org";
@@ -18,15 +18,30 @@ pageMod.PageMod({
       if (msg.bug)
         postAttachment(msg.bug, msg.url);
       else
-        require('tabs').open('https://bugzilla.mozilla.org/enter_bug.cgi');
+        require('sdk/tabs').open('https://bugzilla.mozilla.org/enter_bug.cgi');
     });
   }
 });
 
 function getBugzillaCredentials(cb) {
-  require("passwords").search({
+  require("sdk/passwords").search({
     url: bzUIURL,
     onComplete: function onComplete(credentials) {
+      if (credentials.length > 1) {
+        var message = "You have " + credentials.length +
+          " credentials for bugzilla stored; I don't know which one to use!\n" +
+          "Please clear the ones you don't care about from " +
+          "Preferences... Security... Saved Passwords " +
+          "OR submit an enhancement.\n";
+        credentials.forEach(function(cred) {
+          message += '\n' + cred.username;
+        });
+        require("sdk/notifications").notify({
+          title: "Too Many Accounts!",
+          text: message
+        });
+        return;
+      }
       if (credentials.length) {
         cb(credentials[0]);
         return;
@@ -63,18 +78,18 @@ function postAttachment(bug, pullRequestURL) {
         content_type: "text/html"
       },
       success: function(data) {
-        require("notifications").notify({
+        require("sdk/notifications").notify({
           title: "Success!",
           text: "Your pull request was successfully posted as an attachment to bug " + bug + " on bugzilla.mozilla.org. Forwarding..."
         });
         // Forward the user to the details page for the new attachment.
-        require("tabs").activeTab.url = attachmentDetailsURL + data.id;
+        require("sdk/tabs").activeTab.url = attachmentDetailsURL + data.id;
       },
       error: function(data) {
         var message = "Your pull request was not successfully posted as an attachment to bug " + bug + " on bugzilla.mozilla.org.";
         if (data.json && data.json.message)
           message += " " + data.json.message;
-        require("notifications").notify({
+        require("sdk/notifications").notify({
           title: "Failure!",
           text: message
         });

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "github-and-bugzilla", 
     "license": "MPL 1.1/GPL 2.0/LGPL 2.1", 
     "author": "Dietrich Ayala", 
-    "version": "1.8",
+    "version": "1.10",
     "fullName": "Github tweaks for Bugzilla", 
     "id": "jid0-AWShpy08txla2QGDYvv5bed4sjs", 
     "description": "A set of changes to Github that make it easier to integrate with bugzilla.mozilla.org."


### PR DESCRIPTION
The most recent addon-sdk now requires that "sdk/" be prefixed for SDK
modules, or at least it gets upset if you don't do the update.

The larger fix/warning is that I apparently had 2 sets of bugzilla
credentials on my Firefox.  One of which was out of date.  So depending
on the order in which the credentials were returned, things would either
fail or succeed.  Or maybe it would always fail on this profile and
succeed on another profile.  Unclear.

I didn't really fix the problem, but more have the extension stop arbitrarily
choosing a single credential and instead have it get upset.  This might not
be what you want.
