### PR TITLE
Update linkify function to address changes to Github's markup

### DIFF
--- a/data/tweaks.js
+++ b/data/tweaks.js
@@ -57,7 +57,7 @@ function getBugNumber(str) {
 // Converts 'bug ######' string in pull request title to a link to that
 // bug.
 function linkify() {
-  var title = document.querySelector('.discussion-topic-title');
+  var title = document.querySelector('.js-issue-title');
   if (title) {
     title.innerHTML =
     title.innerHTML.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "github-and-bugzilla", 
     "license": "MPL 1.1/GPL 2.0/LGPL 2.1", 
     "author": "Dietrich Ayala", 
-    "version": "1.20",
+    "version": "1.30",
     "fullName": "Github Tweaks for Bugzilla", 
     "id": "jid0-AWShpy08txla2QGDYvv5bed4sjs", 
     "description": "A set of changes to Github that make it easier to integrate with bugzilla.mozilla.org."


### PR DESCRIPTION
The link to the bug in the title no longer works, as Github's markup has changed. This fixes that.
