### PR TITLE
strip "/files" from PR link

### DIFF
--- a/data/tweaks.js
+++ b/data/tweaks.js
@@ -27,7 +27,9 @@ if (list) {
     var li = makeButton(list, bug);
     var a = li.querySelector('a');
     a.addEventListener("click", function(event) {
-      send(bug, document.location.toString());
+      let url = document.location.toString();
+      url = url.replace(/\/(files|commits)$/, '');
+      send(bug, url);
       event.stopPropagation();
       event.preventDefault();
     });


### PR DESCRIPTION
before attaching the PR link to the bug, i often check out the changes one last time (apparently, i'm not [the only one](https://bugzilla.mozilla.org/show_bug.cgi?id=870677#c14)), and clicking the "attach" button then submit a link that ends with "/files", which makes it not redirect on bugzilla..
