### PR TITLE
add merge warning (squash suggestion) for multiple commits

### DIFF
--- a/data/tweaks.js
+++ b/data/tweaks.js
@@ -1,6 +1,8 @@
 var BGZ_URL = 'https://bugzilla.mozilla.org/show_bug.cgi?id=';
 var list = document.getElementsByClassName("tabnav-tabs")[0];
 
+checkMultipleCommits();
+
 if (list) {
   var bug = getBugNumber(document.title);
   if (bug) {
@@ -74,4 +76,13 @@ function makeButton(containerNode, bug) {
   linkNode.textContent = bug ? "Attach to Bug " + bug :
                                "Submit Bug";
   return buttonNode;
+}
+
+function checkMultipleCommits() {
+  var merge = document.querySelector('.merge-pr');
+  var commits = +document.querySelector('#commits_tab_counter').textContent;
+  if (commits > 1 && merge) { 
+    merge.setAttribute('aria-label', 'WARNING:\n ' + commits + '  commits,\n squash maybe?');
+    merge.classList.add('tooltipped', 'tooltipped-e');
+  }
 }


### PR DESCRIPTION
useful if there is "one commit per PR" policy (common for mozilla), unobtrusive otherwise..
